### PR TITLE
fix: duplicate chapter parents across translations

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -71,6 +71,7 @@ collections:
         value_field: uuid
         search_fields: [title]
         display_fields: [title]
+        i18n: duplicate
         required: false
       - label: Background Image
         name: backgroundImage

--- a/src/collections/chapters/fr/narrative-1-accessing-funds-for-unhoused-people-with-disabilities.md
+++ b/src/collections/chapters/fr/narrative-1-accessing-funds-for-unhoused-people-with-disabilities.md
@@ -5,6 +5,7 @@ shortTitle: Récit 1
 nav: true
 type: narrative
 order: 5
+parent: 85dafcfd-1302-4ed5-8f67-0c43a05e639a
 backgroundImage: /assets/uploads/narrative-1.jpg
 introduction: |-
   ### Données de recherche


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

UUIDs are duplicated across translations to facilitate matching corresponding chapters in English and French. For example, because both _Narratives_ and _Récits_ have the same UUID, we can duplicate the `parent` field for each narrative so that content editors don't have to manually pick the parent when adding French translation. The duplicated `parent` field was missing so this PR adds it.

## Steps to test

1. Add a translation for _Narrative 2_.
**Expected behavior:** See that _Récits_ is already selected as the parent.

## Additional information

Not applicable.

## Related issues

#126